### PR TITLE
feat: partial precomputation support

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -58,12 +58,20 @@ jobs:
     - uses: dtolnay/rust-toolchain@nightly
     - run: cargo test --features "nightly"
 
-  msrv:
-    name: Current MSRV is 1.41
+  build-stable:
+    name: Build (stable)
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: dtolnay/rust-toolchain@1.41
+    - uses: dtolnay/rust-toolchain@stable
+    - run: cargo build
+
+  build-nightly:
+    name: Build (nightly)
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: dtolnay/rust-toolchain@nightly
     - run: cargo build
 
   bench:

--- a/src/backend/serial/scalar_mul/precomputed_straus.rs
+++ b/src/backend/serial/scalar_mul/precomputed_straus.rs
@@ -25,6 +25,7 @@ use window::{NafLookupTable5, NafLookupTable8};
 #[allow(unused_imports)]
 use prelude::*;
 
+#[derive(Clone)]
 pub struct VartimePrecomputedStraus {
     static_lookup_tables: Vec<NafLookupTable8<AffineNielsPoint>>,
 }
@@ -74,7 +75,7 @@ impl VartimePrecomputedMultiscalarMul for VartimePrecomputedStraus {
 
         let sp = self.static_lookup_tables.len();
         let dp = dynamic_lookup_tables.len();
-        assert_eq!(sp, static_nafs.len());
+        assert!(sp >= static_nafs.len());
         assert_eq!(dp, dynamic_nafs.len());
 
         // We could save some doublings by looking for the highest
@@ -93,7 +94,7 @@ impl VartimePrecomputedMultiscalarMul for VartimePrecomputedStraus {
                 }
             }
 
-            for i in 0..sp {
+            for i in 0..static_nafs.len() {
                 let t_ij = static_nafs[i][j];
                 if t_ij > 0 {
                     R = &R.to_extended() + &self.static_lookup_tables[i].select(t_ij as usize);

--- a/src/backend/vector/scalar_mul/precomputed_straus.rs
+++ b/src/backend/vector/scalar_mul/precomputed_straus.rs
@@ -24,6 +24,7 @@ use window::{NafLookupTable5, NafLookupTable8};
 use prelude::*;
 
 
+#[derive(Clone)]
 pub struct VartimePrecomputedStraus {
     static_lookup_tables: Vec<NafLookupTable8<CachedPoint>>,
 }

--- a/src/backend/vector/scalar_mul/precomputed_straus.rs
+++ b/src/backend/vector/scalar_mul/precomputed_straus.rs
@@ -73,7 +73,7 @@ impl VartimePrecomputedMultiscalarMul for VartimePrecomputedStraus {
 
         let sp = self.static_lookup_tables.len();
         let dp = dynamic_lookup_tables.len();
-        assert_eq!(sp, static_nafs.len());
+        assert!(sp >= static_nafs.len());
         assert_eq!(dp, dynamic_nafs.len());
 
         // We could save some doublings by looking for the highest
@@ -92,7 +92,7 @@ impl VartimePrecomputedMultiscalarMul for VartimePrecomputedStraus {
                 }
             }
 
-            for i in 0..sp {
+            for i in 0..static_nafs.len() {
                 let t_ij = static_nafs[i][j];
                 if t_ij > 0 {
                     R = &R + &self.static_lookup_tables[i].select(t_ij as usize);

--- a/src/edwards.rs
+++ b/src/edwards.rs
@@ -757,6 +757,7 @@ impl VartimeMultiscalarMul for EdwardsPoint {
 // decouple stability of the inner type from the stability of the
 // outer type.
 #[cfg(feature = "alloc")]
+#[derive(Clone)]
 pub struct VartimeEdwardsPrecomputation(scalar_mul::precomputed_straus::VartimePrecomputedStraus);
 
 #[cfg(feature = "alloc")]

--- a/src/ristretto.rs
+++ b/src/ristretto.rs
@@ -924,6 +924,7 @@ impl VartimeMultiscalarMul for RistrettoPoint {
 // decouple stability of the inner type from the stability of the
 // outer type.
 #[cfg(feature = "alloc")]
+#[derive(Clone)]
 pub struct VartimeRistrettoPrecomputation(scalar_mul::precomputed_straus::VartimePrecomputedStraus);
 
 #[cfg(feature = "alloc")]
@@ -1380,5 +1381,73 @@ mod test {
 
         assert_eq!(P.compress(), R.compress());
         assert_eq!(Q.compress(), R.compress());
+    }
+
+    #[test]
+    fn partial_precomputed_multiscalar() {
+        let mut rng = rand::thread_rng();
+
+        let n_static = 16;
+        let n_dynamic = 8;
+        
+        let static_points = (0..n_static)
+            .map(|_| RistrettoPoint::random(&mut rng))
+            .collect::<Vec<_>>();
+
+        // Use one fewer scalars
+        let static_scalars = (0..n_static-1)
+            .map(|_| Scalar::random(&mut rng))
+            .collect::<Vec<_>>();
+
+        let dynamic_points = (0..n_dynamic)
+            .map(|_| RistrettoPoint::random(&mut rng))
+            .collect::<Vec<_>>();
+
+        let dynamic_scalars = (0..n_dynamic)
+            .map(|_| Scalar::random(&mut rng))
+            .collect::<Vec<_>>();
+
+        // Compute the linear combination using precomputed multiscalar multiplication
+        let precomputation = VartimeRistrettoPrecomputation::new(static_points.iter());
+        let result_multiscalar = precomputation.vartime_mixed_multiscalar_mul(&static_scalars, &dynamic_scalars, &dynamic_points);
+
+        // Compute the linear combination manually
+        let mut result_manual = RistrettoPoint::identity();
+        for i in 0..static_scalars.len() {
+            result_manual += static_points[i] * static_scalars[i];
+        }
+        for i in 0..n_dynamic {
+            result_manual += dynamic_points[i] * dynamic_scalars[i];
+        }
+
+        assert_eq!(result_multiscalar, result_manual);
+    }
+
+    #[test]
+    fn full_precomputed_multiscalar() {
+        let mut rng = rand::thread_rng();
+
+        let n_static = 16;
+        
+        let static_points = (0..n_static)
+            .map(|_| RistrettoPoint::random(&mut rng))
+            .collect::<Vec<_>>();
+
+        // Use one fewer scalars
+        let static_scalars = (0..n_static-1)
+            .map(|_| Scalar::random(&mut rng))
+            .collect::<Vec<_>>();
+
+        // Compute the linear combination using precomputed multiscalar multiplication
+        let precomputation = VartimeRistrettoPrecomputation::new(static_points.iter());
+        let result_multiscalar = precomputation.vartime_multiscalar_mul(&static_scalars);
+
+        // Compute the linear combination manually
+        let mut result_manual = RistrettoPoint::identity();
+        for i in 0..static_scalars.len() {
+            result_manual += static_points[i] * static_scalars[i];
+        }
+
+        assert_eq!(result_multiscalar, result_manual);
     }
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -265,8 +265,8 @@ pub trait VartimeMultiscalarMul {
 /// allowing decompression to be composed into the input iterators.
 ///
 /// All methods require that the lengths of the input iterators be
-/// known and matching, as if they were `ExactSizeIterator`s.  (It
-/// does not require `ExactSizeIterator` only because that trait is
+/// known, as if they were `ExactSizeIterator`s.  (It does not
+/// require `ExactSizeIterator` only because that trait is
 /// broken).
 pub trait VartimePrecomputedMultiscalarMul: Sized {
     /// The type of point to be multiplied, e.g., `RistrettoPoint`.
@@ -286,8 +286,8 @@ pub trait VartimePrecomputedMultiscalarMul: Sized {
     /// $$
     /// where the \\(B_j\\) are the points that were supplied to `new`.
     ///
-    /// It is an error to call this function with iterators of
-    /// inconsistent lengths.
+    /// It is valid for \\(b_i)\\ to have a shorter length then \\(B_i)\\.
+    /// In this case, any "unused" points are ignored in the computation.
     ///
     /// The trait bound aims for maximum flexibility: the input must
     /// be convertable to iterators (`I: IntoIter`), and the
@@ -317,8 +317,11 @@ pub trait VartimePrecomputedMultiscalarMul: Sized {
     /// $$
     /// where the \\(B_j\\) are the points that were supplied to `new`.
     ///
-    /// It is an error to call this function with iterators of
-    /// inconsistent lengths.
+    /// It is valid for \\(b_i)\\ to have a shorter length then \\(B_i)\\.
+    /// In this case, any "unused" points are ignored in the computation.
+    /// 
+    /// It is an error to call this function if the iterators \\(a_i)\\
+    /// and \\(A_i)\\ do not have equal lengths.
     ///
     /// The trait bound aims for maximum flexibility: the inputs must be
     /// convertable to iterators (`I: IntoIter`), and the iterator's items
@@ -358,8 +361,11 @@ pub trait VartimePrecomputedMultiscalarMul: Sized {
     ///
     /// If any of the dynamic points were `None`, return `None`.
     ///
-    /// It is an error to call this function with iterators of
-    /// inconsistent lengths.
+    /// It is valid for \\(b_i)\\ to have a shorter length then \\(B_i)\\.
+    /// In this case, any "unused" points are ignored in the computation.
+    /// 
+    /// It is an error to call this function if the iterators \\(a_i)\\
+    /// and \\(A_i)\\ do not have equal lengths.
     ///
     /// This function is particularly useful when verifying statements
     /// involving compressed points.  Accepting `Option<Point>` allows


### PR DESCRIPTION
Adds support for variable-time partial precomputation, which is useful for multiscalar multiplication.

Currently, precomputation tables for use in multiscalar multiplication must be generated and used in their entirety; this means it is not possible to generate a superset of precomputation tables and then use only a subset of them for computation without incurring the full computational cost.

With this change, `vartime_mixed_multiscalar_mul` on a `VartimeRistrettoPrecomputation` is allowed to use a static scalar vector that is smaller than the static point vector. In this case, only the static points corresponding to static scalars are used when computing the multiscalar multiplication.

Also adds `Clone` support for precomputation table types, removes the MSRV CI test, and adds build CI tests.