### PR TITLE
chore!: remove precomputation cloning

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -97,7 +97,6 @@ where
 }
 
 #[cfg(feature = "alloc")]
-#[derive(Clone)]
 pub(crate) enum VartimePrecomputedStraus {
     #[cfg(curve25519_dalek_backend = "simd")]
     Avx2(self::vector::scalar_mul::precomputed_straus::spec_avx2::VartimePrecomputedStraus),

--- a/src/backend/serial/scalar_mul/precomputed_straus.rs
+++ b/src/backend/serial/scalar_mul/precomputed_straus.rs
@@ -26,7 +26,6 @@ use crate::traits::Identity;
 use crate::traits::VartimePrecomputedMultiscalarMul;
 use crate::window::{NafLookupTable5, NafLookupTable8};
 
-#[derive(Clone)]
 pub struct VartimePrecomputedStraus {
     static_lookup_tables: Vec<NafLookupTable8<AffineNielsPoint>>,
 }

--- a/src/backend/vector/scalar_mul/precomputed_straus.rs
+++ b/src/backend/vector/scalar_mul/precomputed_straus.rs
@@ -34,7 +34,6 @@ pub mod spec {
     use crate::traits::VartimePrecomputedMultiscalarMul;
     use crate::window::{NafLookupTable5, NafLookupTable8};
 
-    #[derive(Clone)]
     pub struct VartimePrecomputedStraus {
         static_lookup_tables: Vec<NafLookupTable8<CachedPoint>>,
     }

--- a/src/edwards.rs
+++ b/src/edwards.rs
@@ -830,7 +830,6 @@ impl VartimeMultiscalarMul for EdwardsPoint {
 // decouple stability of the inner type from the stability of the
 // outer type.
 #[cfg(feature = "alloc")]
-#[derive(Clone)]
 pub struct VartimeEdwardsPrecomputation(crate::backend::VartimePrecomputedStraus);
 
 #[cfg(feature = "alloc")]

--- a/src/ristretto.rs
+++ b/src/ristretto.rs
@@ -983,7 +983,6 @@ impl VartimeMultiscalarMul for RistrettoPoint {
 // decouple stability of the inner type from the stability of the
 // outer type.
 #[cfg(feature = "alloc")]
-#[derive(Clone)]
 pub struct VartimeRistrettoPrecomputation(crate::backend::VartimePrecomputedStraus);
 
 #[cfg(feature = "alloc")]


### PR DESCRIPTION
Removes precomputation table derived cloning. These tables are very large and it's best to avoid cloning them.

BREAKING CHANGE: Precomputation table cloning is no longer supported.